### PR TITLE
Fix dragons spawning with default health when max_health config is increased

### DIFF
--- a/common/src/main/java/com/leon/saintsdragons/server/entity/dragons/cindervane/Cindervane.java
+++ b/common/src/main/java/com/leon/saintsdragons/server/entity/dragons/cindervane/Cindervane.java
@@ -292,7 +292,6 @@ public class Cindervane extends RideableDragonBase implements DragonFlightCapabl
         }
 
         applyConfiguredAttributes();
-        // Set health to max after applying config to handle increased max_health values
         this.setHealth(this.getMaxHealth());
         return data;
     }

--- a/common/src/main/java/com/leon/saintsdragons/server/entity/dragons/cindervane/Cindervane.java
+++ b/common/src/main/java/com/leon/saintsdragons/server/entity/dragons/cindervane/Cindervane.java
@@ -292,6 +292,8 @@ public class Cindervane extends RideableDragonBase implements DragonFlightCapabl
         }
 
         applyConfiguredAttributes();
+        // Set health to max after applying config to handle increased max_health values
+        this.setHealth(this.getMaxHealth());
         return data;
     }
 

--- a/common/src/main/java/com/leon/saintsdragons/server/entity/dragons/ignivorus/Ignivorus.java
+++ b/common/src/main/java/com/leon/saintsdragons/server/entity/dragons/ignivorus/Ignivorus.java
@@ -414,7 +414,6 @@ public class Ignivorus extends RideableDragonBase implements DragonFlightCapable
                                                  @Nullable CompoundTag dataTag) {
         SpawnGroupData data = super.finalizeSpawn(level, difficulty, spawnType, spawnData, dataTag);
         applyConfiguredAttributes();
-        // Set health to max after applying config to handle increased max_health values
         this.setHealth(this.getMaxHealth());
         return data;
     }

--- a/common/src/main/java/com/leon/saintsdragons/server/entity/dragons/ignivorus/Ignivorus.java
+++ b/common/src/main/java/com/leon/saintsdragons/server/entity/dragons/ignivorus/Ignivorus.java
@@ -414,6 +414,8 @@ public class Ignivorus extends RideableDragonBase implements DragonFlightCapable
                                                  @Nullable CompoundTag dataTag) {
         SpawnGroupData data = super.finalizeSpawn(level, difficulty, spawnType, spawnData, dataTag);
         applyConfiguredAttributes();
+        // Set health to max after applying config to handle increased max_health values
+        this.setHealth(this.getMaxHealth());
         return data;
     }
 

--- a/common/src/main/java/com/leon/saintsdragons/server/entity/dragons/nulljaw/Nulljaw.java
+++ b/common/src/main/java/com/leon/saintsdragons/server/entity/dragons/nulljaw/Nulljaw.java
@@ -218,6 +218,8 @@ public class Nulljaw extends RideableDragonBase implements AquaticDragon, Shakes
         this.nextAmbientSoundDelay = MIN_AMBIENT_DELAY + rng.nextInt(MAX_AMBIENT_DELAY - MIN_AMBIENT_DELAY);
         if (!level.isClientSide) {
             applyConfiguredAttributes();
+            // Set health to max after applying config to handle increased max_health values
+            this.setHealth(this.getMaxHealth());
         }
     }
 

--- a/common/src/main/java/com/leon/saintsdragons/server/entity/dragons/nulljaw/Nulljaw.java
+++ b/common/src/main/java/com/leon/saintsdragons/server/entity/dragons/nulljaw/Nulljaw.java
@@ -218,7 +218,6 @@ public class Nulljaw extends RideableDragonBase implements AquaticDragon, Shakes
         this.nextAmbientSoundDelay = MIN_AMBIENT_DELAY + rng.nextInt(MAX_AMBIENT_DELAY - MIN_AMBIENT_DELAY);
         if (!level.isClientSide) {
             applyConfiguredAttributes();
-            // Set health to max after applying config to handle increased max_health values
             this.setHealth(this.getMaxHealth());
         }
     }

--- a/common/src/main/java/com/leon/saintsdragons/server/entity/dragons/raevyx/Raevyx.java
+++ b/common/src/main/java/com/leon/saintsdragons/server/entity/dragons/raevyx/Raevyx.java
@@ -3174,6 +3174,8 @@ public class Raevyx extends RideableDragonBase implements FlyingAnimal,
         }
 
         applyConfiguredAttributes();
+        // Set health to max after applying config to handle increased max_health values
+        this.setHealth(this.getMaxHealth());
         return spawnData;
     }
 

--- a/common/src/main/java/com/leon/saintsdragons/server/entity/dragons/raevyx/Raevyx.java
+++ b/common/src/main/java/com/leon/saintsdragons/server/entity/dragons/raevyx/Raevyx.java
@@ -3174,7 +3174,6 @@ public class Raevyx extends RideableDragonBase implements FlyingAnimal,
         }
 
         applyConfiguredAttributes();
-        // Set health to max after applying config to handle increased max_health values
         this.setHealth(this.getMaxHealth());
         return spawnData;
     }


### PR DESCRIPTION
Issue:

Dragons were spawning with their default health value even when max_health was increased in configs. For example, Ignivorus with max_health set to 500 would spawn at 300/500 instead of 500/500.

Root Cause:

The issue was that applyConfiguredAttributes() only capped health downward (when max was decreased) but never set it upward. Now explicitly set health to max after applying config on spawn.

Affects: Ignivorus, Raevyx, Nulljaw, Cindervane

(Love the mod, especially Ignivorus being like Fatalis from MH)