### PR TITLE
Add multi-part hitboxes for Ignivorus dragon

### DIFF
--- a/common/src/main/java/com/leon/saintsdragons/client/renderer/ignivorus/IgnivorusRenderer.java
+++ b/common/src/main/java/com/leon/saintsdragons/client/renderer/ignivorus/IgnivorusRenderer.java
@@ -80,8 +80,6 @@ public class IgnivorusRenderer extends GeoEntityRenderer<Ignivorus> {
                 partialTick, packedLight, packedOverlay, red, green, blue, alpha);
     }
 
-    private boolean hasLoggedBones = false;
-
     private void enableTrackingForBones(BakedGeoModel model) {
         if (model == null) {
             return;
@@ -107,17 +105,6 @@ public class IgnivorusRenderer extends GeoEntityRenderer<Ignivorus> {
         model.getBone(RIGHT_FRONT_LEG_BONE).ifPresent(b -> b.setTrackingMatrices(true));
         model.getBone(LEFT_BACK_LEG_BONE).ifPresent(b -> b.setTrackingMatrices(true));
         model.getBone(RIGHT_BACK_LEG_BONE).ifPresent(b -> b.setTrackingMatrices(true));
-
-        // Debug: log which bones were found (only once)
-        if (!hasLoggedBones) {
-            hasLoggedBones = true;
-            System.out.println("[Ignivorus Hitbox Debug] Checking bones:");
-            System.out.println("  headController: " + model.getBone(HEAD_BONE).isPresent());
-            System.out.println("  neck3Controller: " + model.getBone(NECK_BONE).isPresent());
-            System.out.println("  leftwing: " + model.getBone(LEFT_WING_BONE).isPresent());
-            System.out.println("  rightwing: " + model.getBone(RIGHT_WING_BONE).isPresent());
-            System.out.println("  tail1: " + model.getBone(TAIL1_BONE).isPresent());
-        }
     }
 
     @Override

--- a/common/src/main/java/com/leon/saintsdragons/client/renderer/ignivorus/IgnivorusRenderer.java
+++ b/common/src/main/java/com/leon/saintsdragons/client/renderer/ignivorus/IgnivorusRenderer.java
@@ -21,6 +21,20 @@ public class IgnivorusRenderer extends GeoEntityRenderer<Ignivorus> {
     private static final String MOUTH_LOCATOR_BONE = "mouth_origin";
     private static final String BODY_LOCATOR_BONE = "body_locator";
 
+    // Bones for hitbox parts
+    private static final String HEAD_BONE = "headController";
+    private static final String NECK_BONE = "neck3Controller";
+    private static final String LEFT_WING_BONE = "leftwing";
+    private static final String RIGHT_WING_BONE = "rightwing";
+    private static final String TAIL1_BONE = "tail1";
+    private static final String TAIL2_BONE = "tail2";
+    private static final String TAIL3_BONE = "tail3";
+    private static final String TAIL4_BONE = "tail4";
+    private static final String LEFT_FRONT_LEG_BONE = "leftfrontleg";
+    private static final String RIGHT_FRONT_LEG_BONE = "rightfrontleg";
+    private static final String LEFT_BACK_LEG_BONE = "leftbackleg";
+    private static final String RIGHT_BACK_LEG_BONE = "rightbackleg";
+
     private BakedGeoModel lastBakedModel;
 
     public IgnivorusRenderer(EntityRendererProvider.Context renderManager) {
@@ -71,6 +85,20 @@ public class IgnivorusRenderer extends GeoEntityRenderer<Ignivorus> {
         model.getBone(FIRE_BONE).ifPresent(b -> b.setTrackingMatrices(true));
         model.getBone(MOUTH_LOCATOR_BONE).ifPresent(b -> b.setTrackingMatrices(true));
         model.getBone(BODY_LOCATOR_BONE).ifPresent(b -> b.setTrackingMatrices(true));
+
+        // Enable tracking for hitbox bones
+        model.getBone(HEAD_BONE).ifPresent(b -> b.setTrackingMatrices(true));
+        model.getBone(NECK_BONE).ifPresent(b -> b.setTrackingMatrices(true));
+        model.getBone(LEFT_WING_BONE).ifPresent(b -> b.setTrackingMatrices(true));
+        model.getBone(RIGHT_WING_BONE).ifPresent(b -> b.setTrackingMatrices(true));
+        model.getBone(TAIL1_BONE).ifPresent(b -> b.setTrackingMatrices(true));
+        model.getBone(TAIL2_BONE).ifPresent(b -> b.setTrackingMatrices(true));
+        model.getBone(TAIL3_BONE).ifPresent(b -> b.setTrackingMatrices(true));
+        model.getBone(TAIL4_BONE).ifPresent(b -> b.setTrackingMatrices(true));
+        model.getBone(LEFT_FRONT_LEG_BONE).ifPresent(b -> b.setTrackingMatrices(true));
+        model.getBone(RIGHT_FRONT_LEG_BONE).ifPresent(b -> b.setTrackingMatrices(true));
+        model.getBone(LEFT_BACK_LEG_BONE).ifPresent(b -> b.setTrackingMatrices(true));
+        model.getBone(RIGHT_BACK_LEG_BONE).ifPresent(b -> b.setTrackingMatrices(true));
     }
 
     @Override
@@ -107,6 +135,57 @@ public class IgnivorusRenderer extends GeoEntityRenderer<Ignivorus> {
             net.minecraft.world.phys.Vec3 world = transformLocator(b, 0f, 0f, 0f);
             if (world != null) {
                 entity.setClientLocatorPosition("body_locator", world);
+            }
+        });
+
+        // Track hitbox bone positions and sync to server
+        trackBone(HEAD_BONE, "headController", entity);
+        trackBone(NECK_BONE, "neck3Controller", entity);
+        trackBone(LEFT_WING_BONE, "leftwing", entity);
+        trackBone(RIGHT_WING_BONE, "rightwing", entity);
+        trackBone(TAIL1_BONE, "tail1", entity);
+        trackBone(TAIL2_BONE, "tail2", entity);
+        trackBone(TAIL3_BONE, "tail3", entity);
+        trackBone(TAIL4_BONE, "tail4", entity);
+        trackBone(LEFT_FRONT_LEG_BONE, "leftfrontleg", entity);
+        trackBone(RIGHT_FRONT_LEG_BONE, "rightfrontleg", entity);
+        trackBone(LEFT_BACK_LEG_BONE, "leftbackleg", entity);
+        trackBone(RIGHT_BACK_LEG_BONE, "rightbackleg", entity);
+
+        // Send bone positions to server for hitbox sync (every few frames to reduce network load)
+        sendBonePositionsToServer(entity);
+    }
+
+    private int syncTickCounter = 0;
+    private static final int SYNC_INTERVAL = 2; // Sync every 2 frames
+
+    private void sendBonePositionsToServer(Ignivorus entity) {
+        syncTickCounter++;
+        if (syncTickCounter < SYNC_INTERVAL) {
+            return;
+        }
+        syncTickCounter = 0;
+
+        java.util.Map<String, net.minecraft.world.phys.Vec3> positions = new java.util.HashMap<>();
+        for (String boneName : com.leon.saintsdragons.common.network.MessageDragonBonePositions.SYNCED_BONES) {
+            net.minecraft.world.phys.Vec3 pos = entity.getClientLocatorPosition(boneName);
+            if (pos != null) {
+                positions.put(boneName, pos);
+            }
+        }
+
+        if (!positions.isEmpty()) {
+            com.leon.saintsdragons.common.network.NetworkHandler.sendToServer(
+                new com.leon.saintsdragons.common.network.MessageDragonBonePositions(entity.getId(), positions)
+            );
+        }
+    }
+
+    private void trackBone(String boneName, String locatorName, Ignivorus entity) {
+        this.lastBakedModel.getBone(boneName).ifPresent(b -> {
+            net.minecraft.world.phys.Vec3 world = transformLocator(b, 0f, 0f, 0f);
+            if (world != null) {
+                entity.setClientLocatorPosition(locatorName, world);
             }
         });
     }

--- a/common/src/main/java/com/leon/saintsdragons/client/renderer/ignivorus/IgnivorusRenderer.java
+++ b/common/src/main/java/com/leon/saintsdragons/client/renderer/ignivorus/IgnivorusRenderer.java
@@ -24,8 +24,11 @@ public class IgnivorusRenderer extends GeoEntityRenderer<Ignivorus> {
     // Bones for hitbox parts
     private static final String HEAD_BONE = "headController";
     private static final String NECK_BONE = "neck3Controller";
+    private static final String HIP_BONE = "hip";
     private static final String LEFT_WING_BONE = "leftwing";
     private static final String RIGHT_WING_BONE = "rightwing";
+    private static final String LEFT_WING_JOINT_BONE = "leftwingjoint";
+    private static final String RIGHT_WING_JOINT_BONE = "rightwingjoint";
     private static final String TAIL1_BONE = "tail1";
     private static final String TAIL2_BONE = "tail2";
     private static final String TAIL3_BONE = "tail3";
@@ -77,6 +80,8 @@ public class IgnivorusRenderer extends GeoEntityRenderer<Ignivorus> {
                 partialTick, packedLight, packedOverlay, red, green, blue, alpha);
     }
 
+    private boolean hasLoggedBones = false;
+
     private void enableTrackingForBones(BakedGeoModel model) {
         if (model == null) {
             return;
@@ -89,8 +94,11 @@ public class IgnivorusRenderer extends GeoEntityRenderer<Ignivorus> {
         // Enable tracking for hitbox bones
         model.getBone(HEAD_BONE).ifPresent(b -> b.setTrackingMatrices(true));
         model.getBone(NECK_BONE).ifPresent(b -> b.setTrackingMatrices(true));
+        model.getBone(HIP_BONE).ifPresent(b -> b.setTrackingMatrices(true));
         model.getBone(LEFT_WING_BONE).ifPresent(b -> b.setTrackingMatrices(true));
         model.getBone(RIGHT_WING_BONE).ifPresent(b -> b.setTrackingMatrices(true));
+        model.getBone(LEFT_WING_JOINT_BONE).ifPresent(b -> b.setTrackingMatrices(true));
+        model.getBone(RIGHT_WING_JOINT_BONE).ifPresent(b -> b.setTrackingMatrices(true));
         model.getBone(TAIL1_BONE).ifPresent(b -> b.setTrackingMatrices(true));
         model.getBone(TAIL2_BONE).ifPresent(b -> b.setTrackingMatrices(true));
         model.getBone(TAIL3_BONE).ifPresent(b -> b.setTrackingMatrices(true));
@@ -99,6 +107,17 @@ public class IgnivorusRenderer extends GeoEntityRenderer<Ignivorus> {
         model.getBone(RIGHT_FRONT_LEG_BONE).ifPresent(b -> b.setTrackingMatrices(true));
         model.getBone(LEFT_BACK_LEG_BONE).ifPresent(b -> b.setTrackingMatrices(true));
         model.getBone(RIGHT_BACK_LEG_BONE).ifPresent(b -> b.setTrackingMatrices(true));
+
+        // Debug: log which bones were found (only once)
+        if (!hasLoggedBones) {
+            hasLoggedBones = true;
+            System.out.println("[Ignivorus Hitbox Debug] Checking bones:");
+            System.out.println("  headController: " + model.getBone(HEAD_BONE).isPresent());
+            System.out.println("  neck3Controller: " + model.getBone(NECK_BONE).isPresent());
+            System.out.println("  leftwing: " + model.getBone(LEFT_WING_BONE).isPresent());
+            System.out.println("  rightwing: " + model.getBone(RIGHT_WING_BONE).isPresent());
+            System.out.println("  tail1: " + model.getBone(TAIL1_BONE).isPresent());
+        }
     }
 
     @Override
@@ -141,8 +160,11 @@ public class IgnivorusRenderer extends GeoEntityRenderer<Ignivorus> {
         // Track hitbox bone positions and sync to server
         trackBone(HEAD_BONE, "headController", entity);
         trackBone(NECK_BONE, "neck3Controller", entity);
+        trackBone(HIP_BONE, "hip", entity);
         trackBone(LEFT_WING_BONE, "leftwing", entity);
         trackBone(RIGHT_WING_BONE, "rightwing", entity);
+        trackBone(LEFT_WING_JOINT_BONE, "leftwingjoint", entity);
+        trackBone(RIGHT_WING_JOINT_BONE, "rightwingjoint", entity);
         trackBone(TAIL1_BONE, "tail1", entity);
         trackBone(TAIL2_BONE, "tail2", entity);
         trackBone(TAIL3_BONE, "tail3", entity);

--- a/common/src/main/java/com/leon/saintsdragons/common/network/MessageDragonBonePositions.java
+++ b/common/src/main/java/com/leon/saintsdragons/common/network/MessageDragonBonePositions.java
@@ -20,8 +20,11 @@ public record MessageDragonBonePositions(
     public static final String[] SYNCED_BONES = {
             "headController",
             "neck3Controller",
+            "hip",
             "leftwing",
             "rightwing",
+            "leftwingjoint",
+            "rightwingjoint",
             "tail1",
             "tail2",
             "tail3",

--- a/common/src/main/java/com/leon/saintsdragons/common/network/MessageDragonBonePositions.java
+++ b/common/src/main/java/com/leon/saintsdragons/common/network/MessageDragonBonePositions.java
@@ -1,0 +1,80 @@
+package com.leon.saintsdragons.common.network;
+
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.phys.Vec3;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Syncs dragon bone positions from client (where GeckoLib renders) to server (where hitboxes are checked).
+ * This allows hitboxes to follow the animated model precisely.
+ */
+public record MessageDragonBonePositions(
+        int entityId,
+        Map<String, Vec3> bonePositions
+) {
+    // Bone names that we sync for hitbox positioning
+    public static final String[] SYNCED_BONES = {
+            "headController",
+            "neck3Controller",
+            "leftwing",
+            "rightwing",
+            "tail1",
+            "tail2",
+            "tail3",
+            "tail4",
+            "leftfrontleg",
+            "rightfrontleg",
+            "leftbackleg",
+            "rightbackleg"
+    };
+
+    public static void encode(MessageDragonBonePositions msg, FriendlyByteBuf buf) {
+        buf.writeVarInt(msg.entityId());
+        buf.writeVarInt(msg.bonePositions().size());
+        for (Map.Entry<String, Vec3> entry : msg.bonePositions().entrySet()) {
+            buf.writeUtf(entry.getKey());
+            Vec3 pos = entry.getValue();
+            buf.writeDouble(pos.x);
+            buf.writeDouble(pos.y);
+            buf.writeDouble(pos.z);
+        }
+    }
+
+    public static MessageDragonBonePositions decode(FriendlyByteBuf buf) {
+        int entityId = buf.readVarInt();
+        int count = buf.readVarInt();
+        Map<String, Vec3> positions = new HashMap<>(count);
+        for (int i = 0; i < count; i++) {
+            String boneName = buf.readUtf();
+            double x = buf.readDouble();
+            double y = buf.readDouble();
+            double z = buf.readDouble();
+            positions.put(boneName, new Vec3(x, y, z));
+        }
+        return new MessageDragonBonePositions(entityId, positions);
+    }
+
+    public static void handle(MessageDragonBonePositions msg, ServerPlayer player) {
+        if (player == null) {
+            return;
+        }
+
+        // Find the entity in the server world
+        Entity entity = player.serverLevel().getEntity(msg.entityId());
+        if (entity == null) {
+            return;
+        }
+
+        // Update the entity's bone position cache
+        // Currently only Ignivorus supports this
+        if (entity instanceof com.leon.saintsdragons.server.entity.dragons.ignivorus.Ignivorus ignivorus) {
+            for (Map.Entry<String, Vec3> entry : msg.bonePositions().entrySet()) {
+                ignivorus.setServerBonePosition(entry.getKey(), entry.getValue());
+            }
+        }
+    }
+}

--- a/common/src/main/java/com/leon/saintsdragons/common/network/NetworkHandler.java
+++ b/common/src/main/java/com/leon/saintsdragons/common/network/NetworkHandler.java
@@ -37,6 +37,14 @@ public final class NetworkHandler {
         );
 
         NETWORK.registerServerbound(
+                MessageDragonBonePositions.class,
+                id("dragon_bone_positions"),
+                MessageDragonBonePositions::encode,
+                MessageDragonBonePositions::decode,
+                MessageDragonBonePositions::handle
+        );
+
+        NETWORK.registerServerbound(
                 MessageDragonAllyManagement.class,
                 id("dragon_ally_management"),
                 MessageDragonAllyManagement::encode,

--- a/common/src/main/java/com/leon/saintsdragons/server/entity/dragons/ignivorus/Ignivorus.java
+++ b/common/src/main/java/com/leon/saintsdragons/server/entity/dragons/ignivorus/Ignivorus.java
@@ -3271,6 +3271,33 @@ public class Ignivorus extends RideableDragonBase implements DragonFlightCapable
         return this.clientLocatorCache.get(name);
     }
 
+    // ===== SERVER BONE POSITION CACHE (synced from client for hitboxes) =====
+
+    private final Map<String, Vec3> serverBonePositionCache = new java.util.concurrent.ConcurrentHashMap<>();
+
+    /**
+     * Called by network packet to update bone positions on server.
+     * These positions come from the client's GeckoLib renderer.
+     */
+    public void setServerBonePosition(String boneName, Vec3 position) {
+        if (boneName == null || position == null) return;
+        this.serverBonePositionCache.put(boneName, position);
+    }
+
+    /**
+     * Get a bone position for hitbox placement.
+     * On client: uses clientLocatorCache (from renderer)
+     * On server: uses serverBonePositionCache (synced from client)
+     */
+    public Vec3 getBonePositionForHitbox(String boneName) {
+        if (boneName == null) return null;
+        if (this.level().isClientSide) {
+            return this.clientLocatorCache.get(boneName);
+        } else {
+            return this.serverBonePositionCache.get(boneName);
+        }
+    }
+
     // ===== BREEDING (placeholder) =====
 
     @Override

--- a/forge/src/main/java/com/leon/saintsdragons/forge/entity/part/ForgeDragonPart.java
+++ b/forge/src/main/java/com/leon/saintsdragons/forge/entity/part/ForgeDragonPart.java
@@ -1,0 +1,142 @@
+package com.leon.saintsdragons.forge.entity.part;
+
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityDimensions;
+import net.minecraft.world.entity.Pose;
+import net.minecraft.world.phys.AABB;
+import net.minecraftforge.entity.PartEntity;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Forge-specific implementation of dragon hitbox parts using Forge's PartEntity system.
+ * Supports both standard centered boxes and elongated boxes that stretch toward a target point.
+ */
+public class ForgeDragonPart extends PartEntity<Entity> {
+    public final String partName;
+    private EntityDimensions size;
+    private float damageMultiplier = 1.0f;
+    private float baseWidth;
+    private float baseHeight;
+
+    public ForgeDragonPart(Entity parent, String partName, float width, float height) {
+        super(parent);
+        this.partName = partName;
+        this.baseWidth = width;
+        this.baseHeight = height;
+        this.size = EntityDimensions.scalable(width, height);
+        this.refreshDimensions();
+    }
+
+    public ForgeDragonPart setDamageMultiplier(float multiplier) {
+        this.damageMultiplier = multiplier;
+        return this;
+    }
+
+    public float getDamageMultiplier() {
+        return damageMultiplier;
+    }
+
+    public void updatePosition(double x, double y, double z) {
+        this.setPos(x, y, z);
+        this.xOld = x;
+        this.yOld = y;
+        this.zOld = z;
+        this.setBoundingBox(this.size.makeBoundingBox(x, y, z));
+    }
+
+    /**
+     * Updates position and creates an elongated bounding box that stretches toward the next bone.
+     * This eliminates dead zones between adjacent hitbox segments.
+     *
+     * @param x Current bone X position
+     * @param y Current bone Y position
+     * @param z Current bone Z position
+     * @param nextX Next bone X position (to stretch toward)
+     * @param nextY Next bone Y position (to stretch toward)
+     * @param nextZ Next bone Z position (to stretch toward)
+     * @param stretchFactor How far toward the next bone to stretch (0.0-1.0, typically 0.5-0.7)
+     */
+    public void updatePositionElongated(double x, double y, double z,
+                                         double nextX, double nextY, double nextZ,
+                                         float stretchFactor) {
+        this.setPos(x, y, z);
+        this.xOld = x;
+        this.yOld = y;
+        this.zOld = z;
+
+        // Calculate the point we're stretching toward
+        double stretchX = x + (nextX - x) * stretchFactor;
+        double stretchY = y + (nextY - y) * stretchFactor;
+        double stretchZ = z + (nextZ - z) * stretchFactor;
+
+        // Create base box at current position
+        AABB baseBox = this.size.makeBoundingBox(x, y, z);
+
+        // Expand the box to include the stretch point with half the base dimensions
+        double halfWidth = baseWidth / 2.0;
+        double halfHeight = baseHeight / 2.0;
+
+        double minX = Math.min(baseBox.minX, stretchX - halfWidth);
+        double minY = Math.min(baseBox.minY, stretchY - halfHeight);
+        double minZ = Math.min(baseBox.minZ, stretchZ - halfWidth);
+        double maxX = Math.max(baseBox.maxX, stretchX + halfWidth);
+        double maxY = Math.max(baseBox.maxY, stretchY + halfHeight);
+        double maxZ = Math.max(baseBox.maxZ, stretchZ + halfWidth);
+
+        this.setBoundingBox(new AABB(minX, minY, minZ, maxX, maxY, maxZ));
+    }
+
+    @Override
+    public boolean isPickable() {
+        return true;
+    }
+
+    @Override
+    public boolean hurt(@NotNull DamageSource source, float amount) {
+        // Only process damage on server side
+        if (this.level().isClientSide) {
+            return !this.isInvulnerableTo(source);
+        }
+
+        if (this.isInvulnerableTo(source)) {
+            return false;
+        }
+
+        Entity parent = this.getParent();
+        if (parent == null) {
+            return false;
+        }
+
+        // Apply damage multiplier based on which part was hit
+        float adjustedAmount = amount * damageMultiplier;
+        return parent.hurt(source, adjustedAmount);
+    }
+
+    @Override
+    public boolean is(@NotNull Entity entity) {
+        return this == entity || this.getParent() == entity;
+    }
+
+    @Override
+    protected void defineSynchedData() {
+    }
+
+    @Override
+    protected void readAdditionalSaveData(@NotNull net.minecraft.nbt.CompoundTag tag) {
+    }
+
+    @Override
+    protected void addAdditionalSaveData(@NotNull net.minecraft.nbt.CompoundTag tag) {
+    }
+
+    @Override
+    public @NotNull EntityDimensions getDimensions(@NotNull Pose pose) {
+        return this.size;
+    }
+
+    @Override
+    public boolean shouldBeSaved() {
+        return false;
+    }
+}

--- a/forge/src/main/java/com/leon/saintsdragons/forge/entity/part/ForgeIgnivorusPartManager.java
+++ b/forge/src/main/java/com/leon/saintsdragons/forge/entity/part/ForgeIgnivorusPartManager.java
@@ -1,0 +1,143 @@
+package com.leon.saintsdragons.forge.entity.part;
+
+import com.leon.saintsdragons.server.entity.dragons.ignivorus.Ignivorus;
+import net.minecraft.world.phys.Vec3;
+import net.minecraftforge.entity.PartEntity;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Forge-specific part manager for Ignivorus hitbox parts.
+ * Creates hitboxes for each bone that follow the animated model via synced bone positions.
+ * Uses elongated hitboxes that stretch toward adjacent bones to eliminate dead zones.
+ *
+ * Hitbox zones with damage multipliers:
+ * - Head: 1.25x (precision bonus)
+ * - Neck: 1.1x (slight bonus)
+ * - Wings: 0.9x (reduced)
+ * - Body/Legs: 1.0x (normal)
+ * - Tail: 0.8x (reduced)
+ */
+public class ForgeIgnivorusPartManager {
+    private final Ignivorus dragon;
+    private final Map<String, PartConfig> partConfigs = new LinkedHashMap<>();
+    private final Map<String, ForgeDragonPart> parts = new LinkedHashMap<>();
+    private ForgeDragonPart[] partsArray;
+
+    // How far each hitbox stretches toward its neighbor (0.6 = 60% of the way)
+    private static final float STRETCH_FACTOR = 0.6f;
+
+    public ForgeIgnivorusPartManager(Ignivorus dragon) {
+        this.dragon = dragon;
+        initializePartConfigs();
+        initializeParts();
+        this.partsArray = parts.values().toArray(new ForgeDragonPart[0]);
+    }
+
+    /**
+     * Configuration for each hitbox part: bone name, size, damage multiplier, and adjacent bone to stretch toward.
+     * @param boneName The GeckoLib bone this hitbox follows
+     * @param width Hitbox base width
+     * @param height Hitbox base height
+     * @param damageMultiplier Damage multiplier for hits on this part
+     * @param stretchTowardBone The adjacent bone to stretch toward (null for no stretching)
+     */
+    private record PartConfig(String boneName, float width, float height, float damageMultiplier, String stretchTowardBone) {}
+
+    private void initializePartConfigs() {
+        // Head - precision hits deal bonus damage, stretches toward neck
+        partConfigs.put("head", new PartConfig("headController", 2.5f, 2.5f, 1.25f, "neck3Controller"));
+
+        // Neck - slight bonus, stretches toward tail (body connection)
+        partConfigs.put("neck", new PartConfig("neck3Controller", 2.0f, 2.0f, 1.1f, "tail1"));
+
+        // Wings - reduced damage (thin targets), no stretching needed
+        partConfigs.put("leftWing", new PartConfig("leftwing", 3.5f, 2.0f, 0.9f, null));
+        partConfigs.put("rightWing", new PartConfig("rightwing", 3.5f, 2.0f, 0.9f, null));
+
+        // Tail segments - reduced damage, each stretches to the next
+        partConfigs.put("tail1", new PartConfig("tail1", 2.0f, 2.0f, 0.85f, "tail2"));
+        partConfigs.put("tail2", new PartConfig("tail2", 1.8f, 1.8f, 0.8f, "tail3"));
+        partConfigs.put("tail3", new PartConfig("tail3", 1.5f, 1.5f, 0.8f, "tail4"));
+        partConfigs.put("tail4", new PartConfig("tail4", 1.2f, 1.2f, 0.75f, null));
+
+        // Legs - normal damage, no stretching needed
+        partConfigs.put("leftFrontLeg", new PartConfig("leftfrontleg", 1.5f, 2.5f, 1.0f, null));
+        partConfigs.put("rightFrontLeg", new PartConfig("rightfrontleg", 1.5f, 2.5f, 1.0f, null));
+        partConfigs.put("leftBackLeg", new PartConfig("leftbackleg", 1.5f, 2.5f, 1.0f, null));
+        partConfigs.put("rightBackLeg", new PartConfig("rightbackleg", 1.5f, 2.5f, 1.0f, null));
+    }
+
+    private void initializeParts() {
+        for (Map.Entry<String, PartConfig> entry : partConfigs.entrySet()) {
+            String partName = entry.getKey();
+            PartConfig config = entry.getValue();
+            ForgeDragonPart part = new ForgeDragonPart(dragon, partName, config.width(), config.height());
+            part.setDamageMultiplier(config.damageMultiplier());
+            parts.put(partName, part);
+        }
+    }
+
+    public void updatePartPositions() {
+        Vec3 dragonPos = dragon.position();
+        float yawRad = (float) Math.toRadians(dragon.getYRot());
+        double cosYaw = Math.cos(yawRad);
+        double sinYaw = Math.sin(yawRad);
+
+        for (Map.Entry<String, ForgeDragonPart> entry : parts.entrySet()) {
+            String partName = entry.getKey();
+            ForgeDragonPart part = entry.getValue();
+            PartConfig config = partConfigs.get(partName);
+
+            // Try to get synced bone position (works on both client and server)
+            Vec3 bonePos = dragon.getBonePositionForHitbox(config.boneName());
+
+            if (bonePos != null) {
+                // Check if this part should stretch toward an adjacent bone
+                if (config.stretchTowardBone() != null) {
+                    Vec3 stretchTarget = dragon.getBonePositionForHitbox(config.stretchTowardBone());
+                    if (stretchTarget != null) {
+                        // Use elongated hitbox that stretches toward the next bone
+                        part.updatePositionElongated(
+                            bonePos.x, bonePos.y, bonePos.z,
+                            stretchTarget.x, stretchTarget.y, stretchTarget.z,
+                            STRETCH_FACTOR
+                        );
+                        continue;
+                    }
+                }
+                // No stretch target or target not available - use standard positioning
+                part.updatePosition(bonePos.x, bonePos.y, bonePos.z);
+            } else {
+                // Fallback: calculate approximate position from dragon rotation
+                // This is used when no bone data is available yet
+                double forward = 0, up = 2, side = 0;
+                switch (partName) {
+                    case "head" -> { forward = 6.0; up = 4.0; }
+                    case "neck" -> { forward = 4.0; up = 3.5; }
+                    case "leftWing" -> { forward = 0.0; up = 3.0; side = -4.0; }
+                    case "rightWing" -> { forward = 0.0; up = 3.0; side = 4.0; }
+                    case "tail1" -> { forward = -3.0; up = 2.0; }
+                    case "tail2" -> { forward = -5.0; up = 1.5; }
+                    case "tail3" -> { forward = -7.0; up = 1.0; }
+                    case "tail4" -> { forward = -9.0; up = 0.5; }
+                    case "leftFrontLeg" -> { forward = 2.0; up = 0.0; side = -2.0; }
+                    case "rightFrontLeg" -> { forward = 2.0; up = 0.0; side = 2.0; }
+                    case "leftBackLeg" -> { forward = -2.0; up = 0.0; side = -2.0; }
+                    case "rightBackLeg" -> { forward = -2.0; up = 0.0; side = 2.0; }
+                }
+
+                double worldX = dragonPos.x + (cosYaw * forward) - (sinYaw * side);
+                double worldY = dragonPos.y + up;
+                double worldZ = dragonPos.z + (sinYaw * forward) + (cosYaw * side);
+
+                part.updatePosition(worldX, worldY, worldZ);
+            }
+        }
+    }
+
+    public PartEntity<?>[] getParts() {
+        return partsArray;
+    }
+}

--- a/forge/src/main/java/com/leon/saintsdragons/forge/entity/part/ForgeIgnivorusPartManager.java
+++ b/forge/src/main/java/com/leon/saintsdragons/forge/entity/part/ForgeIgnivorusPartManager.java
@@ -25,8 +25,8 @@ public class ForgeIgnivorusPartManager {
     private final Map<String, ForgeDragonPart> parts = new LinkedHashMap<>();
     private ForgeDragonPart[] partsArray;
 
-    // How far each hitbox stretches toward its neighbor (0.6 = 60% of the way)
-    private static final float STRETCH_FACTOR = 0.6f;
+    // How far each hitbox stretches toward its neighbor (0.75 = 75% of the way)
+    private static final float STRETCH_FACTOR = 0.75f;
 
     public ForgeIgnivorusPartManager(Ignivorus dragon) {
         this.dragon = dragon;
@@ -46,21 +46,27 @@ public class ForgeIgnivorusPartManager {
     private record PartConfig(String boneName, float width, float height, float damageMultiplier, String stretchTowardBone) {}
 
     private void initializePartConfigs() {
-        // Head - precision hits deal bonus damage, stretches toward neck
-        partConfigs.put("head", new PartConfig("headController", 2.5f, 2.5f, 1.25f, "neck3Controller"));
+        // Head - precision hits deal bonus damage, longer/narrower box that stretches back to neck
+        partConfigs.put("head", new PartConfig("headController", 3.0f, 2.5f, 1.25f, "neck3Controller"));
 
-        // Neck - slight bonus, stretches toward tail (body connection)
-        partConfigs.put("neck", new PartConfig("neck3Controller", 2.0f, 2.0f, 1.1f, "tail1"));
+        // Neck - slight bonus, stretches toward body to close the gap
+        partConfigs.put("neck", new PartConfig("neck3Controller", 2.5f, 2.5f, 1.1f, "hip"));
 
-        // Wings - reduced damage (thin targets), no stretching needed
-        partConfigs.put("leftWing", new PartConfig("leftwing", 3.5f, 2.0f, 0.9f, null));
-        partConfigs.put("rightWing", new PartConfig("rightwing", 3.5f, 2.0f, 0.9f, null));
+        // Body - covers the main torso area, stretches toward tail
+        partConfigs.put("body", new PartConfig("hip", 4.5f, 4.0f, 1.0f, "tail1"));
+
+        // Wings - reduced damage, stretch toward wing joints
+        partConfigs.put("leftWing", new PartConfig("leftwing", 4.0f, 2.5f, 0.9f, "leftwingjoint"));
+        partConfigs.put("rightWing", new PartConfig("rightwing", 4.0f, 2.5f, 0.9f, "rightwingjoint"));
+        // Outer wings - much larger standalone hitboxes at the wing joints to cover wing span
+        partConfigs.put("leftWingOuter", new PartConfig("leftwingjoint", 8.0f, 3.0f, 0.9f, null));
+        partConfigs.put("rightWingOuter", new PartConfig("rightwingjoint", 8.0f, 3.0f, 0.9f, null));
 
         // Tail segments - reduced damage, each stretches to the next
-        partConfigs.put("tail1", new PartConfig("tail1", 2.0f, 2.0f, 0.85f, "tail2"));
-        partConfigs.put("tail2", new PartConfig("tail2", 1.8f, 1.8f, 0.8f, "tail3"));
-        partConfigs.put("tail3", new PartConfig("tail3", 1.5f, 1.5f, 0.8f, "tail4"));
-        partConfigs.put("tail4", new PartConfig("tail4", 1.2f, 1.2f, 0.75f, null));
+        partConfigs.put("tail1", new PartConfig("tail1", 2.5f, 2.5f, 0.85f, "tail2"));
+        partConfigs.put("tail2", new PartConfig("tail2", 2.0f, 2.0f, 0.8f, "tail3"));
+        partConfigs.put("tail3", new PartConfig("tail3", 1.8f, 1.8f, 0.8f, "tail4"));
+        partConfigs.put("tail4", new PartConfig("tail4", 3.0f, 2.0f, 0.75f, null));  // Larger tip hitbox
 
         // Legs - normal damage, no stretching needed
         partConfigs.put("leftFrontLeg", new PartConfig("leftfrontleg", 1.5f, 2.5f, 1.0f, null));
@@ -116,8 +122,11 @@ public class ForgeIgnivorusPartManager {
                 switch (partName) {
                     case "head" -> { forward = 6.0; up = 4.0; }
                     case "neck" -> { forward = 4.0; up = 3.5; }
+                    case "body" -> { forward = 0.0; up = 3.0; }
                     case "leftWing" -> { forward = 0.0; up = 3.0; side = -4.0; }
                     case "rightWing" -> { forward = 0.0; up = 3.0; side = 4.0; }
+                    case "leftWingOuter" -> { forward = 0.0; up = 3.0; side = -8.0; }
+                    case "rightWingOuter" -> { forward = 0.0; up = 3.0; side = 8.0; }
                     case "tail1" -> { forward = -3.0; up = 2.0; }
                     case "tail2" -> { forward = -5.0; up = 1.5; }
                     case "tail3" -> { forward = -7.0; up = 1.0; }

--- a/forge/src/main/java/com/leon/saintsdragons/forge/mixin/IgnivorusMultipartMixin.java
+++ b/forge/src/main/java/com/leon/saintsdragons/forge/mixin/IgnivorusMultipartMixin.java
@@ -1,0 +1,50 @@
+package com.leon.saintsdragons.forge.mixin;
+
+import com.leon.saintsdragons.forge.entity.part.ForgeIgnivorusPartManager;
+import com.leon.saintsdragons.server.entity.dragons.ignivorus.Ignivorus;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.level.Level;
+import net.minecraftforge.common.extensions.IForgeEntity;
+import net.minecraftforge.entity.PartEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+/**
+ * Mixin to add Forge multi-part entity support to Ignivorus.
+ * Implements IForgeEntity methods for multi-part entity handling.
+ */
+@Mixin(Ignivorus.class)
+public abstract class IgnivorusMultipartMixin implements IForgeEntity {
+
+    @Unique
+    private ForgeIgnivorusPartManager saintsdragons$forgePartManager;
+
+    @Inject(method = "<init>", at = @At("RETURN"))
+    private void onConstruct(EntityType<?> type, Level level, CallbackInfo ci) {
+        this.saintsdragons$forgePartManager = new ForgeIgnivorusPartManager((Ignivorus) (Object) this);
+    }
+
+    @Inject(method = "tick", at = @At("RETURN"))
+    private void onTick(CallbackInfo ci) {
+        if (this.saintsdragons$forgePartManager != null) {
+            this.saintsdragons$forgePartManager.updatePartPositions();
+        }
+    }
+
+    @Override
+    public boolean isMultipartEntity() {
+        boolean result = this.saintsdragons$forgePartManager != null;
+        return result;
+    }
+
+    @Override
+    public PartEntity<?>[] getParts() {
+        if (this.saintsdragons$forgePartManager == null) {
+            return null;
+        }
+        return this.saintsdragons$forgePartManager.getParts();
+    }
+}

--- a/forge/src/main/java/com/leon/saintsdragons/forge/mixin/ServerGamePacketListenerMixin.java
+++ b/forge/src/main/java/com/leon/saintsdragons/forge/mixin/ServerGamePacketListenerMixin.java
@@ -1,0 +1,110 @@
+package com.leon.saintsdragons.forge.mixin;
+
+import com.leon.saintsdragons.forge.entity.part.ForgeDragonPart;
+import net.minecraft.network.protocol.game.ServerboundInteractPacket;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.server.network.ServerGamePacketListenerImpl;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.Vec3;
+import net.minecraftforge.entity.PartEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+/**
+ * Mixin to fix PartEntity attack handling on the server.
+ *
+ * Problem: Client and server create PartEntities independently, so they have different IDs.
+ * When a client attacks a PartEntity, it sends its local entity ID which doesn't exist on the server.
+ *
+ * Solution: When we receive an unknown entity ID, check if the player's look direction
+ * intersects with any PartEntity on the server side, and dispatch the attack to that part.
+ */
+@Mixin(ServerGamePacketListenerImpl.class)
+public abstract class ServerGamePacketListenerMixin {
+
+    @Unique
+    private static final double ATTACK_REACH = 6.0; // Player attack reach
+
+    @Shadow
+    public ServerPlayer player;
+
+    @Inject(method = "handleInteract", at = @At("HEAD"), cancellable = true)
+    private void saintsdragons$onHandleInteract(ServerboundInteractPacket packet, CallbackInfo ci) {
+        ServerLevel level = this.player.serverLevel();
+
+        // Get the entity ID from the packet using our accessor
+        int entityId = ((ServerboundInteractPacketAccessor) packet).getEntityId();
+
+        // First check if vanilla can find it (regular entity)
+        Entity vanillaEntity = level.getEntity(entityId);
+
+        if (vanillaEntity == null) {
+            // Vanilla couldn't find it - the client might be targeting a PartEntity
+            // Since client/server have different part IDs, we need to raycast to find the hit part
+            ForgeDragonPart hitPart = saintsdragons$findHitPartEntity(level);
+
+            if (hitPart != null) {
+                // Dispatch the interaction to the PartEntity
+                packet.dispatch(new ServerboundInteractPacket.Handler() {
+                    @Override
+                    public void onInteraction(InteractionHand hand) {
+                        // Right-click interaction - not used for attacks
+                    }
+
+                    @Override
+                    public void onInteraction(InteractionHand hand, Vec3 pos) {
+                        // Right-click at specific position - not used for attacks
+                    }
+
+                    @Override
+                    public void onAttack() {
+                        player.attack(hitPart);
+                    }
+                });
+
+                // Cancel the original handling since we handled it
+                ci.cancel();
+            }
+        }
+        // If vanillaEntity != null, let vanilla handle it normally
+    }
+
+    /**
+     * Raycast from the player's eye position to find the nearest PartEntity they're looking at.
+     */
+    @Unique
+    private ForgeDragonPart saintsdragons$findHitPartEntity(ServerLevel level) {
+        Vec3 eyePos = player.getEyePosition();
+        Vec3 lookVec = player.getLookAngle();
+        Vec3 reachPos = eyePos.add(lookVec.scale(ATTACK_REACH));
+
+        ForgeDragonPart closestPart = null;
+        double closestDistance = Double.MAX_VALUE;
+
+        // Check all PartEntities in the level
+        for (PartEntity<?> part : level.getPartEntities()) {
+            if (part instanceof ForgeDragonPart forgePart) {
+                AABB box = forgePart.getBoundingBox();
+
+                // Check if the ray from eye to reach position intersects this part's bounding box
+                var clipResult = box.clip(eyePos, reachPos);
+                if (clipResult.isPresent()) {
+                    double distance = eyePos.distanceToSqr(clipResult.get());
+                    if (distance < closestDistance) {
+                        closestDistance = distance;
+                        closestPart = forgePart;
+                    }
+                }
+            }
+        }
+
+        return closestPart;
+    }
+}

--- a/forge/src/main/java/com/leon/saintsdragons/forge/mixin/ServerboundInteractPacketAccessor.java
+++ b/forge/src/main/java/com/leon/saintsdragons/forge/mixin/ServerboundInteractPacketAccessor.java
@@ -1,0 +1,16 @@
+package com.leon.saintsdragons.forge.mixin;
+
+import net.minecraft.network.protocol.game.ServerboundInteractPacket;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+/**
+ * Accessor mixin to expose the private entityId field from ServerboundInteractPacket.
+ * This is needed to properly look up PartEntities on the server side.
+ */
+@Mixin(ServerboundInteractPacket.class)
+public interface ServerboundInteractPacketAccessor {
+
+    @Accessor("entityId")
+    int getEntityId();
+}

--- a/forge/src/main/resources/saintsdragons.mixins.json
+++ b/forge/src/main/resources/saintsdragons.mixins.json
@@ -1,8 +1,12 @@
 {
   "required": true,
-  "package": "com.leon.saintsdragons.mixin",
+  "package": "com.leon.saintsdragons.forge.mixin",
   "compatibilityLevel": "JAVA_17",
-  "mixins": [],
+  "mixins": [
+    "IgnivorusMultipartMixin",
+    "ServerboundInteractPacketAccessor",
+    "ServerGamePacketListenerMixin"
+  ],
   "client": [
   ],
   "server": [


### PR DESCRIPTION
Hey! 

This is an unsolicited feature PR so I 100% understand if it's not something you want in the mod or if it doesn't fit your vision. Just thought it could be a cool addition and wanted to share the work in case it's useful.

What this does:

Adds segmented hitboxes to Ignivorus that follow the animated model, kind of like how the Ender Dragon works. Players can now target different body parts (head, neck, body, wings, tail, legs) instead of just swinging at a single hitbox centered on the body. 

- 16 hitbox segments that track bone positions from GeckoLib
- Hitboxes stretch between adjacent bones to minimize dead zones
- Damage multipliers per body part (head 1.25x, neck 1.1x, wings/tail reduced)

Notes:

It's not pixel-perfect, but an improvement over a single centered hitbox. I think combat just feels better when you can aim for specific parts

Only Ignivorus has this implemented if you want to put this in a separate branch until all dragons are finished if you decide to merge.

Feel free to tweak the damage multipliers or hitbox sizes to fit your balancing
Just sharing in case it's helpful!