### PR TITLE
Fix dragon model pop-in when partially off-screen

### DIFF
--- a/common/src/main/java/com/leon/saintsdragons/server/entity/dragons/cindervane/Cindervane.java
+++ b/common/src/main/java/com/leon/saintsdragons/server/entity/dragons/cindervane/Cindervane.java
@@ -2012,6 +2012,16 @@ public class Cindervane extends RideableDragonBase implements DragonFlightCapabl
         return super.hurt(source, amount);
     }
 
+    /**
+     * Returns a larger bounding box for frustum culling to prevent the model from
+     * disappearing when the entity's collision box is off-screen but the visual model
+     * (wings, tail, etc.) should still be visible.
+     */
+    @Override
+    public AABB getBoundingBoxForCulling() {
+        return super.getBoundingBoxForCulling().inflate(6.0, 3.0, 6.0);
+    }
+
     @Override
     protected DragonAbilityType<?, ?> getDeathAbilityType() {
         return CindervaneAbilities.DIE;

--- a/common/src/main/java/com/leon/saintsdragons/server/entity/dragons/ignivorus/Ignivorus.java
+++ b/common/src/main/java/com/leon/saintsdragons/server/entity/dragons/ignivorus/Ignivorus.java
@@ -560,6 +560,17 @@ public class Ignivorus extends RideableDragonBase implements DragonFlightCapable
         return super.hurt(damageSource, amount);
     }
 
+    /**
+     * Returns a larger bounding box for frustum culling to prevent the model from
+     * disappearing when the entity's collision box is off-screen but the visual model
+     * (wings, tail, etc.) should still be visible.
+     */
+    @Override
+    public AABB getBoundingBoxForCulling() {
+        // Expand the culling box significantly to account for wings, tail, and neck
+        return super.getBoundingBoxForCulling().inflate(8.0, 4.0, 8.0);
+    }
+
     @Override
     protected @NotNull PathNavigation createNavigation(@NotNull Level level) {
         return groundNav;

--- a/common/src/main/java/com/leon/saintsdragons/server/entity/dragons/nulljaw/Nulljaw.java
+++ b/common/src/main/java/com/leon/saintsdragons/server/entity/dragons/nulljaw/Nulljaw.java
@@ -2050,6 +2050,16 @@ public class Nulljaw extends RideableDragonBase implements AquaticDragon, Shakes
         return super.hurt(damageSource, amount);
     }
 
+    /**
+     * Returns a larger bounding box for frustum culling to prevent the model from
+     * disappearing when the entity's collision box is off-screen but the visual model
+     * (wings, tail, etc.) should still be visible.
+     */
+    @Override
+    public net.minecraft.world.phys.AABB getBoundingBoxForCulling() {
+        return super.getBoundingBoxForCulling().inflate(8.0, 4.0, 8.0);
+    }
+
     @Override
     public void addAdditionalSaveData(@NotNull net.minecraft.nbt.CompoundTag tag) {
         super.addAdditionalSaveData(tag);

--- a/common/src/main/java/com/leon/saintsdragons/server/entity/dragons/raevyx/Raevyx.java
+++ b/common/src/main/java/com/leon/saintsdragons/server/entity/dragons/raevyx/Raevyx.java
@@ -3367,6 +3367,16 @@ public class Raevyx extends RideableDragonBase implements FlyingAnimal,
         // Neutral behavior: do not proactively target players. Only retaliate when hurt or defend owner.
     }
 
+    /**
+     * Returns a larger bounding box for frustum culling to prevent the model from
+     * disappearing when the entity's collision box is off-screen but the visual model
+     * (wings, tail, etc.) should still be visible.
+     */
+    @Override
+    public AABB getBoundingBoxForCulling() {
+        return super.getBoundingBoxForCulling().inflate(5.0, 3.0, 5.0);
+    }
+
     @Override
     public boolean hurt(@Nonnull DamageSource damageSource, float amount) {
         // During dying sequence, ignore all damage (entity is already dead, playing death animation)

--- a/common/src/main/java/com/leon/saintsdragons/server/entity/dragons/stegonaut/Stegonaut.java
+++ b/common/src/main/java/com/leon/saintsdragons/server/entity/dragons/stegonaut/Stegonaut.java
@@ -252,6 +252,16 @@ public class Stegonaut extends DragonEntity implements SoundHandledDragon {
         return super.hurt(source, amount);
     }
 
+    /**
+     * Returns a larger bounding box for frustum culling to prevent the model from
+     * disappearing when the entity's collision box is off-screen but the visual model
+     * should still be visible.
+     */
+    @Override
+    public net.minecraft.world.phys.AABB getBoundingBoxForCulling() {
+        return super.getBoundingBoxForCulling().inflate(6.0, 3.0, 6.0);
+    }
+
     @Override
     protected DragonAbilityType<?, ?> getDeathAbilityType() {
         return StegonautAbilities.STEGONAUT_DIE;


### PR DESCRIPTION
Fixes the frustum culling issue where dragons would disappear when their collision box went off-screen, even though parts of the model (wings, tail, neck) were still visible. Added getBoundingBoxForCulling() override to all dragon entities to expand the render culling box beyond the collision box.